### PR TITLE
diff element not optional

### DIFF
--- a/reactpy_vdom/reconcile.mojo
+++ b/reactpy_vdom/reconcile.mojo
@@ -102,7 +102,7 @@ struct ListPatch(Copyable, Movable, Defaultable, EqualityComparable, Stringable,
         return self.patches.__str__()
 
 
-fn diff(src: Element, dst: Element, path: List[Int] = []) -> ListPatch:
+fn diff(ref src: Element, ref dst: Element, path: List[Int] = []) -> ListPatch:
     patches = ListPatch([])
 
     # case replace
@@ -148,8 +148,8 @@ fn _diff_children_index(src: List[Element], dst: List[Element], path: List[Int] 
             patches.append(Patch(action="remove", path=path + [i], value=None))
             continue
 
-        src_child = src[i]
-        dst_child = dst[i]
+        ref src_child = src[i]
+        ref dst_child = dst[i]
         child_path = path + [i]
         patches += diff(src_child, dst_child, child_path)
 

--- a/reactpy_vdom/reconcile.mojo
+++ b/reactpy_vdom/reconcile.mojo
@@ -20,7 +20,7 @@ struct Patch(Copyable, Movable, EqualityComparable, Representable, Stringable):
         if self.action == "insert":
             root.insert(self.path, self.value.value())
         elif self.action == "remove":
-            root.remove(self.path)
+            _ = root.remove(self.path)
         elif self.action == "replace":
             root.set(self.path, self.value.value())
         elif self.action == "update":

--- a/reactpy_vdom/vdom.mojo
+++ b/reactpy_vdom/vdom.mojo
@@ -19,21 +19,19 @@ struct Element(Copyable, Movable, Defaultable, EqualityComparable, Stringable, R
         self.text = Optional[String](None)
         self.key = Optional[String](None)
 
-    fn __init__(out self, tag: String, attributes: Dict[String, String], children: List[Element], key: Optional[String] = None):
+    fn __init__(out self, owned tag: String, owned attributes: Dict[String, String], owned children: List[Element], owned key: Optional[String] = None):
         self.tag = tag
         self.attributes = attributes
         self.children = children
         self.text = Optional[String](None)
         self.key = key
-        # self.key = Optional[String](None)
 
-    fn __init__(out self, tag: String, attributes: Dict[String, String], text: String, key: Optional[String] = None):
+    fn __init__(out self, owned tag: String, owned attributes: Dict[String, String], owned text: String, owned key: Optional[String] = None):
         self.tag = tag
         self.attributes = attributes
         self.children = []
         self.text = Optional(text)
         self.key = key
-        # self.key = Optional[String](None)
 
     fn __eq__(self, other: Self) -> Bool:
         return self.tag == other.tag and dict_equal(self.attributes, other.attributes) and self.children == other.children and self.text == other.text and self.key == other.key
@@ -64,21 +62,6 @@ struct Element(Copyable, Movable, Defaultable, EqualityComparable, Stringable, R
         s += "</" + self.tag + ">"
 
         return s
-
-    # fn get(ref self, path: List[Int]) raises -> ref [self] Self:
-    #     """Get node at path."""
-    #     var current = Pointer(to=self)
-    #     for index in path:
-    #         debug_assert(-len(current[].children) <= index < len(current[].children), "index: ",
-    #             index,
-    #             " is out of bounds for `children` of length: ",
-    #             len(current[].children))
-    #         if index < 0 or index >= len(current[].children):
-    #             current_ = Pointer(to=current[].children[index])
-    #             current = rebind[Pointer[Element, __origin_of(self)]](current_)
-    #         else:
-    #             raise Error("index: ", index, " is out of bounds for `children` of length: ", len(current[].children))
-    #     return current[]
 
     fn get(ref self, path: List[Int]) raises -> ref [self] Self:
         """Get node at path."""

--- a/test/test_vdom.mojo
+++ b/test/test_vdom.mojo
@@ -79,14 +79,14 @@ def test_remove():
     ])
 
     # check root (can't remove at root)
-    root.remove([])
+    _ = root.remove([])
     assert_equal(root, Element("ul", {}, [
         Element("li", {}, "foo"),
         Element("li", {}, "bar"),
     ]))
 
     # check nested
-    root.remove([1])
+    _ = root.remove([1])
     assert_equal(root.children, [
         Element("li", {}, "foo")
     ])


### PR DESCRIPTION
before

| name                        | met (ms)             | iters  | throughput (GElems/s)  | min (ms)            | mean (ms)            | max (ms)            | duration (ms) |
| --------------------------- | -------------------- | ------ | ---------------------- | ------------------- | -------------------- | ------------------- | ------------- |
| create_rows[1000]           | 10.56829             | 100    | 9.462268730324396e-05  | 10.56829            | 10.56829             | 10.56829            | 1056.829      |
| diff_append_row[1000+1000]  | 61.337789473684204   | 19     | 3.2606326657044946e-05 | 61.33778947368421   | 61.337789473684204   | 61.33778947368421   | 1165.418      |
| diff_clear_rows[1000]       | 13.536988636363638   | 88     | 0.00014774334630284871 | 13.536988636363636  | 13.536988636363638   | 13.536988636363636  | 1191.255      |
| diff_select_row[1000]       | 37.03865625          | 32     | 2.6998819645353632e-05 | 37.03865625         | 37.03865625          | 37.03865625         | 1185.237      |
| diff_partial_update[1000]   | 37.07612903225806    | 31     | 2.6971531983016642e-05 | 37.076129032258066  | 37.07612903225806    | 37.076129032258066  | 1149.36       |
| diff_swap_rows[1000]        | 37.68334375          | 32     | 2.6536923226193274e-05 | 37.68334375         | 37.68334375          | 37.68334375         | 1205.867      |

after `diff(src: Optional[Element], dst: Optional[Element])` -> `diff(src: Element, dst: Element)`

| name                       | met (ms)           | iters | throughput (GElems/s)  | min (ms)           | mean (ms)          | max (ms)           | duration (ms) |
| -------------------------- | ------------------ | ----- | ---------------------- | ------------------ | ------------------ | ------------------ | ------------- |
| create_rows[1000]          | 9.38824            | 100   | 0.00010651623733521941 | 9.38824            | 9.38824            | 9.38824            | 938.824       |
| diff_append_row[1000+1000] | 25.326787234042552 | 47    | 7.896777358763199e-05  | 25.326787234042552 | 25.326787234042552 | 25.326787234042552 | 1190.359      |
| diff_clear_rows[1000]      | 1.803960902255639  | 665   | 0.0011086714781341643  | 1.803960902255639  | 1.803960902255639  | 1.803960902255639  | 1199.634      |
| diff_select_row[1000]      | 13.342022471910113 | 89    | 7.495115542680052e-05  | 13.342022471910111 | 13.342022471910113 | 13.342022471910111 | 1187.44       |
| diff_partial_update[1000]  | 13.666790697674418 | 86    | 7.317006765678815e-05  | 13.666790697674418 | 13.666790697674418 | 13.666790697674418 | 1175.344      |
| diff_swap_rows[1000]       | 13.342712643678162 | 87    | 7.494727846618242e-05  | 13.34271264367816  | 13.342712643678162 | 13.34271264367816  | 1160.816      |

after `diff(src: Element, dst: Element)` -> `diff(ref src: Element, ref dst: Element)`

| name                       | met (ms)            | iters | throughput (GElems/s)  | min (ms)            | mean (ms)           | max (ms)            | duration (ms) |
| -------------------------- | ------------------- | ----- | ---------------------- | ------------------- | ------------------- | ------------------- | ------------- |
| create_rows[1000]          | 9.32243             | 100   | 0.00010726816935069506 | 9.32243             | 9.32243             | 9.32243             | 932.243       |
| diff_append_row[1000+1000] | 11.03455            | 100   | 0.00018124889551454298 | 11.03455            | 11.03455            | 11.03455            | 1103.455      |
| diff_clear_rows[1000]      | 0.39518236877523555 | 2972  | 0.005060954531444502   | 0.39518236877523555 | 0.39518236877523555 | 0.39518236877523555 | 1174.482      |
| diff_select_row[1000]      | 2.5792954048140047  | 457   | 0.00038770278043127486 | 2.579295404814004   | 2.5792954048140047  | 2.579295404814004   | 1178.738      |
| diff_partial_update[1000]  | 2.936480198019802   | 404   | 0.00034054375734402854 | 2.9364801980198023  | 2.936480198019802   | 2.9364801980198023  | 1186.338      |
| diff_swap_rows[1000]       | 2.652197802197802   | 455   | 0.0003770457841309302  | 2.6521978021978025  | 2.652197802197802   | 2.6521978021978025  | 1206.75       |

after `Element.__init__(out self, tag: String, ...)` -> `Element.__init__(out self, owned tag: String, ...)`

| name                       | met (ms)           | iters | throughput (GElems/s)  | min (ms)           | mean (ms)          | max (ms)           | duration (ms) |
| -------------------------- | ------------------ | ----- | ---------------------- | ------------------ | ------------------ | ------------------ | ------------- |
| create_rows[1000]          | 2.4790159362549797 | 502   | 0.00040338586992332454 | 2.47901593625498   | 2.4790159362549797 | 2.47901593625498   | 1244.466      |
| diff_append_row[1000+1000] | 11.7159            | 100   | 0.0001707081828967472  | 11.7159            | 11.7159            | 11.7159            | 1171.59       |
| diff_clear_rows[1000]      | 0.4055382860866732 | 3069  | 0.004931716852925085   | 0.4055382860866732 | 0.4055382860866732 | 0.4055382860866732 | 1244.597      |
| diff_select_row[1000]      | 2.55019375         | 480   | 0.0003921270687766371  | 2.55019375         | 2.55019375         | 2.55019375         | 1224.093      |
| diff_partial_update[1000]  | 2.908754716981132  | 424   | 0.00034378973041695863 | 2.908754716981132  | 2.908754716981132  | 2.908754716981132  | 1233.312      |
| diff_swap_rows[1000]       | 2.5630127388535033 | 471   | 0.000390165832904648   | 2.563012738853503  | 2.5630127388535033 | 2.563012738853503  | 1207.179      |